### PR TITLE
Refactor error handling in ezTime module

### DIFF
--- a/src/ezTime.cpp
+++ b/src/ezTime.cpp
@@ -135,7 +135,8 @@ namespace ezt {
 		}
 	}
 
-	ezError_t error(const bool reset /* = false */) {
+	ezError_t error(ezError_t err, const bool reset /* = false */) {
+		_last_error = err;
 		ezError_t tmp = _last_error;
 		if (reset) _last_error = NO_ERROR;
 		return tmp;

--- a/src/ezTime.h
+++ b/src/ezTime.h
@@ -182,7 +182,7 @@ namespace ezt {
 	String dayStr(const uint8_t month);
 	void deleteEvent(const uint8_t event_handle);
 	void deleteEvent(void (*function)());
-	ezError_t error(const bool reset = false);
+	ezError_t error(ezError_t err, const bool reset = false);
 	String errorString(const ezError_t err = LAST_ERROR);
 	void events();
 	time_t makeOrdinalTime(const uint8_t hour, const uint8_t minute, const uint8_t second, uint8_t ordinal, const uint8_t wday, const uint8_t month, uint16_t year);


### PR DESCRIPTION
- Updated the `error` function to accept an additional parameter `err`
- Set the `_last_error` variable to the value of `err`
- Modified the signature of the `error` function in the header file accordingly